### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/snippy/admin/js/script.js
+++ b/snippy/admin/js/script.js
@@ -80,7 +80,7 @@ var Snippy = (function(undefined){
 			tags.push(tag);
 			var value = '';
 			if (str.indexOf(':')!==-1 && tag !== 'content') {
-				value = str.match(/:(.+)}}$/)[0].substr(1).replace(/}}$/,'');
+				value = str.match(/:(.+)}}$/)[0].slice(1).replace(/}}$/,'');
 			}
 			return '<li><span class="snippy--bit-placeholder-name">' + tag + '</span><span class="snippy--bit-placeholder-default">' + value + '</span></li>';
 		}).filter(function(item){ return item !== null }).join('');


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.